### PR TITLE
Required BooleanProperty

### DIFF
--- a/couchdbkit/schema/properties.py
+++ b/couchdbkit/schema/properties.py
@@ -251,6 +251,10 @@ class BooleanProperty(Property):
         
         return value
 
+    def empty(self, value):
+        """test if boolean is empty"""
+        return value is None
+
 class DecimalProperty(Property):
     """ Decimal property, map to Decimal python object
     

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -538,6 +538,15 @@ class PropertyTestCase(unittest.TestCase):
             test.string = ""
         self.assertRaises(BadValueError, test.save)
 
+    def testRequiredBoolean(self):
+        class Test(Document):
+            boolean = BooleanProperty(required=True)
+        Test._db = self.db
+
+        test = Test()
+        test.boolean = False
+        test.save()
+
     def testValidator(self):
         def test_validator(value):
             if value == "test":


### PR DESCRIPTION
BooleanProperty was using the base Property `empty` function. This was causing validation to fail on False BooleanPropertys when marked as required. Test included. Thanks!
