### PR TITLE
Add SetProperty and LazySet

### DIFF
--- a/couchdbkit/__init__.py
+++ b/couchdbkit/__init__.py
@@ -26,7 +26,8 @@ DateProperty, TimeProperty, dict_to_json, dict_to_json, dict_to_json,\
 value_to_python, dict_to_python, DocumentSchema, DocumentBase, Document,\
 StaticDocument, QueryMixin, AttachmentMixin, SchemaProperty, SchemaListProperty,\
 SchemaDictProperty, \
-ListProperty, DictProperty, StringListProperty, contain, StringProperty
+ListProperty, DictProperty, StringListProperty, contain, StringProperty, \
+SetProperty
 
 except ImportError:
     import traceback

--- a/couchdbkit/schema/__init__.py
+++ b/couchdbkit/schema/__init__.py
@@ -159,9 +159,10 @@ threadsafe.
 from .properties import ALLOWED_PROPERTY_TYPES, Property, StringProperty, \
 IntegerProperty, DecimalProperty, BooleanProperty, FloatProperty, \
 DateTimeProperty, DateProperty, TimeProperty, DictProperty, \
-ListProperty, StringListProperty, dict_to_json, list_to_json, \
+ListProperty, StringListProperty, SetProperty, dict_to_json, list_to_json, \
 value_to_json, MAP_TYPES_PROPERTIES, value_to_python, dict_to_python, \
-list_to_python, convert_property, value_to_property, LazyDict, LazyList
+list_to_python, convert_property, value_to_property, LazyDict, LazyList, \
+LazySet
 from .base import ReservedWordError, ALLOWED_PROPERTY_TYPES, \
 DocumentSchema, SchemaProperties, DocumentBase, QueryMixin, \
 AttachmentMixin, Document, StaticDocument, valid_id


### PR DESCRIPTION
I don't know why this pull request references 21 commits. The changes for SetProperty and LazySet are all in https://github.com/douglatornell/couchdbkit/commit/d0de152bf2c2848b54edb8ebdbb3bd81e591677c Can you just pull that in? Maybe I should kill my fork and start a new one...

Anyway, LazySet sub-classes collections.MutableSet instead of the builtin set because the update method is not reliable when you sub-class builtin set. Some of the core python-dev guys helped me sort that out - glad I was doing this work at PyCon so that they were so close by to help.
