### PR TITLE
fix to_json() to include inline attachments, in case they exist

### DIFF
--- a/couchdbkit/schema/base.py
+++ b/couchdbkit/schema/base.py
@@ -153,6 +153,9 @@ class DocumentSchema(object):
         if self._doc.get('doc_type') is None:
             doc_type = getattr(self, '_doc_type', self.__class__.__name__)
             self._doc['doc_type'] = doc_type
+
+        if getattr(self, '_attachments'):
+            self._doc['_attachments'] = self['_attachments']
         return self._doc
 
     #TODO: add a way to maintain custom dynamic properties


### PR DESCRIPTION
Very simple change, if the '_attachments' attribute exists in the Document, it is included in the to_json() function. This allows inline attributes to be saved with a Document.save(), fixing the bug I created moments ago (https://github.com/benoitc/couchdbkit/issues/#issue/78).
