### PR TITLE
Fixed setup.py error when installing couchdbkit package.

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,6 @@
 include LICENSE
 include README.rst
 include distribute_setup.py
-recursive-include docs *
+recursive-include doc *
 recursive-include tests/data *
 recursive-include tests *

--- a/couchdbkit/__init__.py
+++ b/couchdbkit/__init__.py
@@ -30,8 +30,13 @@ ListProperty, DictProperty, StringListProperty, contain, StringProperty, \
 SetProperty
 
 except ImportError:
-    import traceback
-    traceback.print_exc()
+    # When installing couchdbkit package, setup.py only needs __version__ and
+    # because required packages such as restkit likely not installed yet, do
+    # not show traceback caused by ImportError.
+    import sys
+    if not sys.argv[0].endswith('setup.py'):
+        import traceback
+        traceback.print_exc()
 
 import logging    
 


### PR DESCRIPTION
- Fixed warning:
  
  ```
  warning: no files found matching '*' under directory 'docs'
  ```
- Fixed exception:
  
  When installing couchdbkit from github this exception is outputted:
  
  ```
  Traceback (most recent call last):
    File "/home/sirex/devel/manoseimas/manoseimas.lt/parts/couchdbkit/couchdbkit/__init__.py", line 10, in <module>
      from .resource import  RequestFailed, CouchdbResource
    File "/home/sirex/devel/manoseimas/manoseimas.lt/parts/couchdbkit/couchdbkit/resource.py", line 25, in <module>
      from restkit import Resource, ClientResponse
  ImportError: No module named restkit
  ```
  
  This error is caused by this line from setup.py:
  
  ```
  from couchdbkit import __version__
  ```
  
  Of course couchdbkit/__init__.py file catches this import exception and
  installs correctly, but when installing, such errors should not be
  outputted.
  
  To avoid showing this exception I did some checking if this import was made
  by setup.py file.
