### PR TITLE
Fixed default argument in SchemaProperty (Fix)

### DIFF
--- a/couchdbkit/schema/properties_proxy.py
+++ b/couchdbkit/schema/properties_proxy.py
@@ -54,7 +54,7 @@ class SchemaProperty(Property):
             required=False, validators=None, default=None):
 
         Property.__init__(self, verbose_name=None,
-            name=None, required=False, validators=None)
+            name=None, required=False, validators=None, default=default)
        
         use_instance = True
         if isinstance(schema, type):
@@ -73,6 +73,8 @@ class SchemaProperty(Property):
         
     def default_value(self):
         if not self._use_instance:
+            if self.default:
+                return self.default
             return self._schema()
         return self._schema.clone()
 

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -833,6 +833,56 @@ class PropertyTestCase(unittest.TestCase):
         two = DocTwo(name='two', one=one)
         three = DocThree(name='three', two=two)
         self.assert_(three.two.one.name == 'one')
+
+    def testSchemaPropertyDefault(self):
+        class DocOne(DocumentSchema):
+            name = StringProperty()
+            
+        class DocTwo(Document):
+            one = SchemaProperty(DocOne, default=DocOne(name='12345'))
+        
+        two = DocTwo()
+        self.assert_(two.one.name == '12345')
+        
+    def testSchemaPropertyDefault2(self):
+        class DocOne(DocumentSchema):
+            name = StringProperty()
+            field2 = StringProperty(default='54321')
+                    
+        default_one = DocOne()
+        default_one.name ='12345'
+        
+        class DocTwo(Document):
+            one = SchemaProperty(DocOne, default=default_one)
+        
+        two = DocTwo()
+        self.assert_(two.one.name == '12345')
+        self.assert_(two.one.field2 == '54321')
+    
+    def testSchemaPropertyDefault3(self):
+        class DocOne(Document):
+            name = StringProperty()
+            
+        class DocTwo(Document):
+            one = SchemaProperty(DocOne, default=DocOne(name='12345'))
+
+        two = DocTwo()
+        self.assert_(two.one.name == '12345')
+    
+    def testSchemaPropertyDefault4(self):
+        class DocOne(Document):
+            name = StringProperty()
+            field2 = StringProperty(default='54321')
+        
+        default_one = DocOne()
+        default_one.name ='12345'
+        
+        class DocTwo(Document):
+            one = SchemaProperty(DocOne, default=default_one)
+        
+        two = DocTwo()
+        self.assert_(two.one.name == '12345')
+        self.assert_(two.one.field2 == '54321')
         
     def testSchemaWithPythonTypes(self):
         class A(Document):


### PR DESCRIPTION
When passing a default value for SchemaProperty, it did not propagate correctly.
It now passes the instance back if it is the default, otherwise will just create a new instance.
I have included 4 test cases.

Thanks!

(Past request https://github.com/benoitc/couchdbkit/pull/104 had an extra commit that was not meant to be included)
