### PR TITLE
Bring restkit RequestFailed a bit closer to front

### DIFF
--- a/couchdbkit/exceptions.py
+++ b/couchdbkit/exceptions.py
@@ -6,7 +6,7 @@
 """
 All exceptions used in couchdbkit.
 """
-from restkit.errors import ResourceError
+from restkit.errors import ResourceError, RequestFailed
 
 class InvalidAttachment(Exception):
     """ raised when an attachment is invalid """


### PR DESCRIPTION
I am getting some 503s from time to time. That means I have to go
all the way to importing restkit to handle these errors gracefully.
This is strictly my opinion but this makes it a little bit easier
to find these exceptions.

Catching the problem and reducing the stack trace to a minimum would
also make sense since these exceptions are never raised based on
something that happened inside couchdbkit or restkit.
