### PR TITLE
Add StringDictProperty

### DIFF
--- a/couchdbkit/__init__.py
+++ b/couchdbkit/__init__.py
@@ -26,7 +26,7 @@ from .schema import (
     DocumentSchema, DocumentBase, Document, StaticDocument, contain,
     QueryMixin, AttachmentMixin,
     SchemaProperty, SchemaListProperty, SchemaDictProperty,
-    ListProperty, DictProperty, StringListProperty, SetProperty
+    ListProperty, DictProperty, StringDictProperty, StringListProperty, SetProperty
 )
 
 import logging

--- a/couchdbkit/ext/django/schema.py
+++ b/couchdbkit/ext/django/schema.py
@@ -37,8 +37,8 @@ __all__ = ['Property', 'StringProperty', 'IntegerProperty',
             'value_to_python', 'dict_to_python', 'list_to_python',
             'convert_property', 'DocumentSchema', 'Document',
             'SchemaProperty', 'SchemaListProperty', 'ListProperty',
-            'DictProperty', 'StringListProperty', 'SchemaDictProperty',
-            'SetProperty',]
+            'DictProperty', 'StringDictProperty', 'StringListProperty',
+            'SchemaDictProperty', 'SetProperty',]
 
 
 DEFAULT_NAMES = ('verbose_name', 'db_table', 'ordering',
@@ -169,6 +169,7 @@ SchemaProperty = schema.SchemaProperty
 SchemaListProperty = schema.SchemaListProperty
 ListProperty = schema.ListProperty
 DictProperty = schema.DictProperty
+StringDictProperty = schema.StringDictProperty
 StringListProperty = schema.StringListProperty
 SchemaDictProperty = schema.SchemaDictProperty
 SetProperty = schema.SetProperty

--- a/couchdbkit/schema/__init__.py
+++ b/couchdbkit/schema/__init__.py
@@ -168,6 +168,7 @@ from .properties import (
         DateProperty,
         TimeProperty,
         DictProperty,
+        StringDictProperty,
         ListProperty,
         StringListProperty,
         SetProperty,

--- a/couchdbkit/schema/properties.py
+++ b/couchdbkit/schema/properties.py
@@ -25,8 +25,8 @@ from couchdbkit.exceptions import BadValueError
 __all__ = ['ALLOWED_PROPERTY_TYPES', 'Property', 'StringProperty',
         'IntegerProperty', 'DecimalProperty', 'BooleanProperty',
         'FloatProperty', 'DateTimeProperty', 'DateProperty',
-        'TimeProperty', 'DictProperty', 'ListProperty',
-        'StringListProperty',
+        'TimeProperty', 'DictProperty', 'StringDictProperty',
+        'ListProperty', 'StringListProperty',
         'dict_to_json', 'list_to_json',
         'value_to_json', 'MAP_TYPES_PROPERTIES', 'value_to_python',
         'dict_to_python', 'list_to_python', 'convert_property',
@@ -449,6 +449,22 @@ class DictProperty(Property):
 
     def to_json(self, value):
         return value_to_json(value)
+
+
+
+class StringDictProperty(DictProperty):
+
+    def to_python(self, value):
+        return LazyDict(value, item_type=basestring)
+
+    def validate_dict_contents(self, value):
+        try:
+            value = validate_dict_content(value, basestring)
+        except BadValueError:
+            raise BadValueError(
+                'Items of %s dict must all be in %s' %
+                    (self.name, basestring))
+        return value
 
 
 


### PR DESCRIPTION
Ensures that all dict values are string types. The DictProperty
converts the value '802.11' (see example below) into a Decimal
property. The StringDictProperty prevents this conversion.

Example:

``` javascript
{
  "name" : {
    "de" : "Stadt",
    "en" : "City",
    "xx" : "802.11"
  }
}
```
