### PR TITLE
bring back get_test_db_name from PR #172

### DIFF
--- a/couchdbkit/ext/django/testrunner.py
+++ b/couchdbkit/ext/django/testrunner.py
@@ -22,10 +22,13 @@ class CouchDbKitTestSuiteRunner(DjangoTestSuiteRunner):
     
     dbs = []
 
+    def get_test_db_name(self, dbname):
+        return "%s_test" % dbname
+
     def get_test_db(self, db):
         # not copying DB would modify the db dict and add multiple "_test"
         test_db = db.copy()
-        test_db['URL'] = '%s_test' % test_db['URL']
+        test_db['URL'] = self.get_test_db_name(test_db['URL'])
         return test_db
 
     def setup_databases(self, **kwargs):


### PR DESCRIPTION
This is an amendment to PR #172 (see https://github.com/benoitc/couchdbkit/pull/172/files#L0L26).

To see the diff of that PR plus this one combined, see: https://github.com/dannyroberts/couchdbkit/compare/2dbfd25...get_test_db_name.
