### PR TITLE
Signals

### DIFF
--- a/couchdbkit/designer/fs.py
+++ b/couchdbkit/designer/fs.py
@@ -210,6 +210,8 @@ class FSDoc(object):
                         if name.endswith('/'):
                             name = name[:-1]
                         dmanifest[name] = i
+                    if fname.endswith("py"):
+                        self._doc['language'] = "python"
 
                 for vname, value in self._doc['views'].iteritems():
                     if value and isinstance(value, dict):

--- a/couchdbkit/schema/base.py
+++ b/couchdbkit/schema/base.py
@@ -14,6 +14,8 @@ convert_property, MAP_TYPES_PROPERTIES, ALLOWED_PROPERTY_TYPES, \
 LazyDict, LazyList
 from ..exceptions import DuplicatePropertyError, ResourceNotFound, \
 ReservedWordError
+from django.db.models.signals import pre_save, post_save, pre_delete, post_delete, \
+pre_init, post_init
 
 
 __all__ = ['ReservedWordError', 'ALLOWED_PROPERTY_TYPES', 'DocumentSchema',
@@ -427,6 +429,9 @@ class DocumentBase(DocumentSchema):
 
         @params db: couchdbkit.core.Database instance
         """
+        # Signal that the save is starting
+        pre_save.send(sender=self.__class__, instance=self, raw=False, using=None,
+                      update_fields=None)
         self.validate()
         db = self.get_db()
 
@@ -436,6 +441,10 @@ class DocumentBase(DocumentSchema):
             self._doc.update(doc)
         elif '_id' in doc:
             self._doc.update({'_id': doc['_id']})
+
+        # Signal that the save is complete
+        post_save.send(sender=self.__class__, instance=self, created=True,
+                       update_fields=None, raw=False, using=None)
 
     store = save
 

--- a/couchdbkit/schema/properties.py
+++ b/couchdbkit/schema/properties.py
@@ -64,7 +64,7 @@ class Property(object):
     creation_counter = 0
 
     def __init__(self, verbose_name=None, name=None,
-            default=None, required=False, validators=None,
+            default=None, required=False, validators=[],
             choices=None):
         """ Default constructor for a property.
 


### PR DESCRIPTION
I needed these changes for a project at work (we use CouchDB and SQL with Django and django-rest-framework). They only add functionality so I thought other people might want to use them. Will likely also start updating to Django 1.9 in the near future.

Changes: 
- added signal emitters to DocumentBase.save
- added support for python-couchdb python views
- changed default validators to not break things when no validators are added

I can add the other model signals if necessary, and am happy to make changes.

First PR to a public repo :smile: 
